### PR TITLE
Registering for an account creates Parent

### DIFF
--- a/src/main/java/org/launchcode/liftoffproject/controllers/AuthenticationController.java
+++ b/src/main/java/org/launchcode/liftoffproject/controllers/AuthenticationController.java
@@ -1,6 +1,7 @@
 package org.launchcode.liftoffproject.controllers;
 
 import org.launchcode.liftoffproject.data.UserRepository;
+import org.launchcode.liftoffproject.models.Parent;
 import org.launchcode.liftoffproject.models.User;
 import org.launchcode.liftoffproject.models.dto.LoginFormDTO;
 import org.launchcode.liftoffproject.models.dto.RegisterFormDTO;
@@ -75,9 +76,9 @@ public class AuthenticationController {
             return "register";
         }
 
-        User newUser = new User(registerFormDTO.getUsername(), registerFormDTO.getPassword());
-        userRepository.save(newUser);
-        setUserInSession(request.getSession(), newUser);
+        Parent newParent = new Parent(registerFormDTO.getUsername(), registerFormDTO.getPassword(), registerFormDTO.getFirstName(), registerFormDTO.getLastName());
+        userRepository.save(newParent);
+        setUserInSession(request.getSession(), newParent);
 
         return "redirect:";
     }

--- a/src/main/java/org/launchcode/liftoffproject/models/Parent.java
+++ b/src/main/java/org/launchcode/liftoffproject/models/Parent.java
@@ -24,8 +24,10 @@ public class Parent extends User {
     @OneToMany(mappedBy = "parentCreator")
     private List<Chore> chores = new ArrayList<>();
 
+    public Parent() {}
 
-    public Parent(String firstName, String lastName) {
+    public Parent(String username, String password, String firstName, String lastName) {
+        super(username, password);
         this.firstName = firstName;
         this.lastName = lastName;
     }

--- a/src/main/java/org/launchcode/liftoffproject/models/dto/RegisterFormDTO.java
+++ b/src/main/java/org/launchcode/liftoffproject/models/dto/RegisterFormDTO.java
@@ -1,8 +1,19 @@
 package org.launchcode.liftoffproject.models.dto;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
 public class RegisterFormDTO extends LoginFormDTO {
 
     private String verifyPassword;
+
+    @NotBlank(message = "First Name is required")
+    @Size(max = 50, message = "Name is too long")
+    private String firstName;
+
+    @NotBlank (message = "Last Name is required")
+    @Size (max = 50, message = "Last Name is too long")
+    private String lastName;
 
     public String getVerifyPassword() {
         return verifyPassword;
@@ -12,4 +23,19 @@ public class RegisterFormDTO extends LoginFormDTO {
         this.verifyPassword = verifyPassword;
     }
 
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
 }

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -7,6 +7,18 @@
 
 <form method="post">
    <div class="form-group">
+      <label>First Name
+         <input class="form-control" th:field="${registerFormDTO.firstName}" />
+      </label>
+      <p class="error" th:errors="${registerFormDTO.firstName}"></p>
+   </div>
+   <div class="form-group">
+      <label>Last Name
+         <input class="form-control" th:field="${registerFormDTO.lastName}" />
+      </label>
+      <p class="error" th:errors="${registerFormDTO.lastName}"></p>
+   </div>
+   <div class="form-group">
       <label>Username
          <input class="form-control" th:field="${registerFormDTO.username}" />
       </label>


### PR DESCRIPTION
We want all users who register via the site to be of type `Parent`, so I modified the `registerFormDTO` to require `firstName` and `lastName` fields, refactored the constructor in `Parent` to inherit/call the constructor in `User`. I copied the validation annotations from `firstName` and `lastName` in the `Parent` class to appear in the `registerFormDTO` class as well.

Testing Steps:
1. Checkout branch locally
2. Run program
3. Register for new accounts (try to break it)
4. Check the user table in MYSQL (remember to refresh it)