### PR TITLE
44 add image to header in fragments

### DIFF
--- a/src/main/java/org/launchcode/liftoffproject/AuthenticationFilter.java
+++ b/src/main/java/org/launchcode/liftoffproject/AuthenticationFilter.java
@@ -21,7 +21,7 @@ public class AuthenticationFilter extends HandlerInterceptorAdapter {
     @Autowired
     AuthenticationController authenticationController;
 
-    private static final List<String> whitelist = Arrays.asList("/login", "/register", "/logout", "/css");
+    private static final List<String> whitelist = Arrays.asList("/login", "/register", "/logout", "/css", "/images");
 
     private static boolean isWhitelisted(String path) {
         for (String pathRoot : whitelist) {


### PR DESCRIPTION
The image should appear now. I moved the `/images` directory inside the `/static` folder in the `resources` directory.

I also added `/images` to the whitelist, so that it appears even if a user is not logged in.

We can work on the actual display of the image (sizing, if we want to put it into the navBar, etc.) separately (or if you can workout a quick fix, commit it to this branch prior to the PR merge).

Testing steps:
1. Checkout branch locally.
2. bootRun application and open localhost:8080 in a browser.
3. Verify that the image appears. Try logging in and navigating to other pages to make sure it stays.