### PR TITLE
Renamed variable to `childUser` instead of `userType`

### DIFF
--- a/src/main/java/org/launchcode/liftoffproject/AuthenticationFilter.java
+++ b/src/main/java/org/launchcode/liftoffproject/AuthenticationFilter.java
@@ -66,20 +66,7 @@ public class AuthenticationFilter extends HandlerInterceptorAdapter {
 
         if (user instanceof ChildUser) {
             System.out.println("This is a child user");
-            model.addObject("userType","userType");
+            model.addObject("childUser","childUser");
         }
     }
-
-//    public boolean afterCompletion(HttpServletRequest request, HttpServletResponse response, Model model) {
-//        HttpSession session = request.getSession();
-//        User user = authenticationController.getUserFromSession(session);
-//
-//        if (user instanceof ChildUser) {
-//        System.out.println("This is a child user");
-//        model.addAttribute("userType", "userType");
-//        return true;
-//    }
-//
-//        return true;
-//}
 }

--- a/src/main/resources/templates/chores/index.html
+++ b/src/main/resources/templates/chores/index.html
@@ -4,7 +4,7 @@
 <body>
 <header th:replace="fragments :: header"></header>
 
-<h1 th:if="${userType}" th:text="${'THIS IS A CHILD USER'}"></h1>
+<h1 th:if="${childUser}" th:text="${'THIS IS A CHILD USER'}"></h1>
 <p th:unless="${chores} and ${chores.size()}">No chores!</p>
 <table class="table table-striped">
     <thead>


### PR DESCRIPTION
My last PR introduced a way of determining if a user was a ChildUser and then passing a variable to the view so that we can render a different view for ChildUsers.

This PR just renames the variable to `childUser` instead of `userType`, since if the user is not a child user we won't need to pass anything.