### PR TITLE
Child can claim unassigned chores

### DIFF
--- a/src/main/java/org/launchcode/liftoffproject/controllers/ChoreController.java
+++ b/src/main/java/org/launchcode/liftoffproject/controllers/ChoreController.java
@@ -175,6 +175,18 @@ public class ChoreController {
 
     }
 
+    @PostMapping("claim")
+    public String claimChore(@RequestParam Integer choreId, HttpSession session){
+        Chore chore = choreRepository.findById(choreId).orElse(null);
+        Child child = authenticationController.getChildFromSession(session);
+
+        if (chore != null) {
+            chore.setChildAssigned(child);
+            choreRepository.save(chore);
+        }
+        return "redirect:/chores";
+    }
+
 
 
 //    @GetMapping("/chores/{dueDate}")

--- a/src/main/java/org/launchcode/liftoffproject/controllers/ChoreController.java
+++ b/src/main/java/org/launchcode/liftoffproject/controllers/ChoreController.java
@@ -41,7 +41,7 @@ public class ChoreController {
 
             if (authenticationController.getChildFromSession(session) != null) {
                 Child child = authenticationController.getChildFromSession(session);
-                model.addAttribute("chores", choreRepository.findAllByChildAssigned(child));
+                model.addAttribute("chores", choreRepository.findByChildAssignedOrChildAssignedIsNullAndParentCreator(child, child.getParent()));
             } else {
                 Parent parent = authenticationController.getParentFromSession(session);
                 model.addAttribute("chores", choreRepository.findAllByParentCreatorAndApprovedByParent(parent, false));

--- a/src/main/java/org/launchcode/liftoffproject/data/ChoreRepository.java
+++ b/src/main/java/org/launchcode/liftoffproject/data/ChoreRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
+
 import java.time.LocalDate;
 import java.util.List;
 
@@ -20,6 +21,8 @@ public interface ChoreRepository extends PagingAndSortingRepository<Chore, Integ
     List<Chore> findAllByParentCreatorAndApprovedByParent(Parent parent, boolean approved);
 
     List<Chore> findAllByChildAssigned(Child child);
+
+    List<Chore> findByChildAssignedOrChildAssignedIsNullAndParentCreator(Child child, Parent parent);
 
     List<Chore> findAllByChildAssignedAndApprovedByParent(Child child, boolean approved);
 

--- a/src/main/resources/templates/chores/edit.html
+++ b/src/main/resources/templates/chores/edit.html
@@ -26,6 +26,7 @@
                   <option th:each="child : ${crew}"
                           th:value="${child.id}"
                           th:text="${child.firstName}"></option>
+                  <option th:value="${null}" th:text="None"></option>
               </select>
               <p class="error" th:errors="${chore.childAssigned}"></p>
           </label>

--- a/src/main/resources/templates/chores/index.html
+++ b/src/main/resources/templates/chores/index.html
@@ -67,7 +67,11 @@
                                        th:if="${not chore.completed}">Mark as Complete</a>
                     <span th:if="${chore.completed}" class="text-success">Completed</span>
                 </td>
-                <td th:unless="${chore.childAssigned}">Claim this task</td>
+                <td th:unless="${chore.childAssigned}">
+                    <form th:action="@{/chores/claim}" method="post">
+                        <input type="hidden" name="choreId" th:value="${chore.id}" />
+                        <button type="submit" class="btn btn-outline-dark">Claim this task</button>
+                    </form></td>
             </tr>
         </table>
     </th:block>

--- a/src/main/resources/templates/chores/index.html
+++ b/src/main/resources/templates/chores/index.html
@@ -52,7 +52,7 @@
                 <th>Due Date</th>
                 <th>Point Value</th>
                 <th>Supplies</th>
-                <th>Completed</th>
+                <th>Action</th>
             </tr>
             </thead>
             <tr th:each="chore : ${chores}">
@@ -61,6 +61,13 @@
                 <td th:text="${#temporals.format(chore.dueDate, 'yyyy-MM-dd')}"></td>
                 <td th:text="${chore.rewardPoints}"></td>
                 <td th:text="${chore.supplies}"></td>
+                <td th:if="${chore.childAssigned}">
+                    <a th:href="@{/chores/complete(choreId=${chore.id},completed=true)}"
+                                       class="btn btn-primary"
+                                       th:if="${not chore.completed}">Mark as Complete</a>
+                    <span th:if="${chore.completed}" class="text-success">Completed</span>
+                </td>
+                <td th:unless="${chore.childAssigned}">Claim this task</td>
             </tr>
         </table>
     </th:block>


### PR DESCRIPTION
Now that Parent's do not have to assign a particular crew member to a task, I've made it so that those unassigned tasks show up on the "Tasks" page for an individual child, along with a button that they can click that will "Claim that Task" and make them the child to which the task is assigned.

Seems to be working properly but make sure you test it!

Also make sure you log in as different users to make sure you can't see unassigned tasks created by other parents. I'm reasonably sure I got the syntax right for that but it was a lot of trial and error so we'll see.