### PR TITLE
139 clean up chore details view

### DIFF
--- a/src/main/resources/static/styles.css
+++ b/src/main/resources/static/styles.css
@@ -421,6 +421,7 @@ footer {
 /*style for comments on chore detail*/
 
 .comment-area {
+    margin: auto;
     width:70%;
     padding: 10px;
     border-radius: 4px;
@@ -428,8 +429,10 @@ footer {
     box-shadow: 2px 2px 20px 23px #00000;
 }
 .comment-box {
+    margin: auto;
     width: 95%;
-    height: 50%;
+    align-items: center;
+    height: auto;
     padding: 10px;
     border-radius: 25px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
@@ -442,4 +445,8 @@ footer {
 .comment-attribution {
     font-size: 60%;
     text-align: right;
+}
+
+.section-buffer {
+    padding: 10px;
 }

--- a/src/main/resources/static/styles.css
+++ b/src/main/resources/static/styles.css
@@ -417,3 +417,29 @@ footer {
 .child-chore-table{
     margin-top: 10px;
 }
+
+/*style for comments on chore detail*/
+
+.comment-area {
+    width:70%;
+    padding: 10px;
+    border-radius: 4px;
+    background: #eeeeee;
+    box-shadow: 2px 2px 20px 23px #00000;
+}
+.comment-box {
+    width: 95%;
+    height: 50%;
+    padding: 10px;
+    border-radius: 25px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    background-color: #ffffff;
+}
+.comments {
+    font-size: 120%;
+}
+
+.comment-attribution {
+    font-size: 60%;
+    text-align: right;
+}

--- a/src/main/resources/templates/chores/detail.html
+++ b/src/main/resources/templates/chores/detail.html
@@ -11,7 +11,7 @@
 <main class="container">
 
     <h1 class="text-center">Ship-Shapin Task Details</h1>
-  
+
    <table class="table table-striped">
       <tr>
           <th>Name</th>
@@ -43,8 +43,14 @@
            <td th:text="${chore.supplies}"></td>
        </tr>
   </table>
-  <div class="comment-area">
-      <div class="comment-box" th:each="comment : ${chore.comments}">
+<div class="section-buffer">
+    <a th:unless="${childUser}" class="btn btn-outline-dark" th:href="'/chores/edit?choreId=' + ${chore.id}" role="button">Edit This Task</a>
+</div>
+<div class="comment-area">
+    <h2 class="text-center">Squawk</h2>
+</div>
+  <div class="comment-area" th:each="comment : ${chore.comments}">
+      <div class="comment-box">
           <p class="comments" th:text= "${comment.text}"></p>
           <div class="comment-attribution">
           <p th:if="${comment.createdBy instanceof T(org.launchcode.liftoffproject.models.ParentUser)}" th:text="${'Comment by Captain ' + comment.createdBy.getParent.firstName + ' ' + comment.createdBy.getParent.lastName}"></p>
@@ -52,30 +58,36 @@
           <p th:text="${'Created on ' +  #temporals.format(comment.createdDate, 'MM-dd-yyyy')} "></p>
           </div>
       </div>
-      <form th:action="@{/chores/comment}" method="post">
+  </div>
+    <div class="comment-area">
+        <form th:action="@{/chores/comment}" method="post">
           <input type="hidden" name="choreId" th:value="${chore.id}" />
           <input type="hidden" name="createdBy" th:value="${user.id}" />
 
           <div class="form-group">
               <input class="form-control" type="text" th:field="${newComment.text}"/>
           </div>
-          <button type="submit" class="btn btn-success">Add Comment</button>
-      </form>
-  </div>
-
-    <a th:unless="${childUser}" class="btn btn-outline-dark" th:href="'/chores/edit?choreId=' + ${chore.id}" role="button">Edit This Task</a>
+          <button type="submit" class="btn btn-outline-dark">Add Comment</button>
+        </form>
+    </div>
 
   <!-- Mark as Complete Form -->
+    <div class="section-buffer">
+        <h2 class="text-center">Task Status</h2>
   <form th:unless="${chore.completed}" th:action="@{/chores/complete(choreId=${chore.id},completed=true)}" method="get">
       <input type="hidden" name="choreId" th:value="${chore.id}" />
       <button type="submit" class="btn btn-primary">Mark as Complete</button>
   </form>
+        <p th:if="${chore.completed}" th:text="${chore.childAssigned.firstName + ' marked this task as complete.'}"></p>
+    </div>
 
   <!-- Approve Chore Form -->
+    <div class="section-buffer">
   <form th:unless="${childUser}" th:action="@{/chores/approve}" method="post">
       <input type="hidden" name="choreId" th:value="${chore.id}" />
       <button type="submit" class="btn btn-success">Approve</button>
   </form>
+    </div>
 
 
 

--- a/src/main/resources/templates/chores/detail.html
+++ b/src/main/resources/templates/chores/detail.html
@@ -43,22 +43,25 @@
            <td th:text="${chore.supplies}"></td>
        </tr>
   </table>
-  <div class="flex-container" th:each="comment : ${chore.comments}">
-      <div th:if="${comment.createdBy instanceof T(org.launchcode.liftoffproject.models.ParentUser)}" th:text="${'Comment by Captain ' + comment.createdBy.getParent.firstName + ' ' + comment.createdBy.getParent.lastName}"></div>
-      <div th:if="${comment.createdBy instanceof T(org.launchcode.liftoffproject.models.ChildUser)}" th:text="${'Comment by Crew Member ' + comment.createdBy.getChild.firstName + ' ' + comment.createdBy.getChild.lastName}"></div>
-      <div th:text= "${comment.text}">Comment</div>
-      <div>Created On</div>
-      <div th:text="${comment.createdDate}" >Date</div>
-  </div>
-  <form th:action="@{/chores/comment}" method="post">
-      <input type="hidden" name="choreId" th:value="${chore.id}" />
-      <input type="hidden" name="createdBy" th:value="${user.id}" />
-
-      <div class="form-group">
-          <input class="form-control" type="text" th:field="${newComment.text}"/>
+  <div class="comment-area">
+      <div class="comment-box" th:each="comment : ${chore.comments}">
+          <p class="comments" th:text= "${comment.text}"></p>
+          <div class="comment-attribution">
+          <p th:if="${comment.createdBy instanceof T(org.launchcode.liftoffproject.models.ParentUser)}" th:text="${'Comment by Captain ' + comment.createdBy.getParent.firstName + ' ' + comment.createdBy.getParent.lastName}"></p>
+          <p th:if="${comment.createdBy instanceof T(org.launchcode.liftoffproject.models.ChildUser)}" th:text="${'Comment by Crew Member ' + comment.createdBy.getChild.firstName + ' ' + comment.createdBy.getChild.lastName}"></p>
+          <p th:text="${'Created on ' +  #temporals.format(comment.createdDate, 'MM-dd-yyyy')} "></p>
+          </div>
       </div>
-      <button type="submit" class="btn btn-success">Add Comment</button>
-  </form>
+      <form th:action="@{/chores/comment}" method="post">
+          <input type="hidden" name="choreId" th:value="${chore.id}" />
+          <input type="hidden" name="createdBy" th:value="${user.id}" />
+
+          <div class="form-group">
+              <input class="form-control" type="text" th:field="${newComment.text}"/>
+          </div>
+          <button type="submit" class="btn btn-success">Add Comment</button>
+      </form>
+  </div>
 
     <a th:unless="${childUser}" class="btn btn-outline-dark" th:href="'/chores/edit?choreId=' + ${chore.id}" role="button">Edit This Task</a>
 


### PR DESCRIPTION
I refactored `chores/details.html` to display the comments on a task differently, and I rearranged the buttons on the page so that they weren't all clustered together.
The comment display is a definite improvement, but I also recognize it's not top-quality design, so happy to have other folks jump in to tweak it.
<img width="1066" alt="image" src="https://github.com/SenecaAurelius/liftoff-project/assets/46571147/8e639965-cc8c-46ac-87ca-273d23773143">


In a later update I'll add a button/method to reject a child's completed chore (effectively making `completed=false`)