### PR TITLE
141 as a parent i can reject a childs task completion

### DIFF
--- a/src/main/java/org/launchcode/liftoffproject/controllers/ChoreController.java
+++ b/src/main/java/org/launchcode/liftoffproject/controllers/ChoreController.java
@@ -134,7 +134,7 @@ public class ChoreController {
 
     // Endpoint for marking a chore complete by the child
     @PostMapping("/complete")
-    public String markChoreComplete(@RequestParam Integer choreId, @RequestParam boolean completed) {
+    public String markChoreComplete(@RequestParam Integer choreId, @RequestParam boolean completed, @RequestParam String source) {
         Chore chore = choreRepository.findById(choreId).orElse(null);
 
         if (chore != null) {
@@ -149,7 +149,7 @@ public class ChoreController {
             }
             choreRepository.save(chore);
 
-        return "redirect:/chores/detail?choreId=" + choreId;
+        return "redirect:" + source;
     }
 
     //Endpoint for reject a child's chore completion

--- a/src/main/java/org/launchcode/liftoffproject/controllers/ChoreController.java
+++ b/src/main/java/org/launchcode/liftoffproject/controllers/ChoreController.java
@@ -133,7 +133,7 @@ public class ChoreController {
     }
 
     // Endpoint for marking a chore complete by the child
-    @GetMapping("/complete")
+    @PostMapping("/complete")
     public String markChoreComplete(@RequestParam Integer choreId, @RequestParam boolean completed) {
         Chore chore = choreRepository.findById(choreId).orElse(null);
 

--- a/src/main/java/org/launchcode/liftoffproject/controllers/ChoreController.java
+++ b/src/main/java/org/launchcode/liftoffproject/controllers/ChoreController.java
@@ -149,7 +149,7 @@ public class ChoreController {
             }
             choreRepository.save(chore);
 
-        return "redirect:/chores";
+        return "redirect:/chores/detail?choreId=" + choreId;
     }
 
     //Endpoint for reject a child's chore completion
@@ -163,7 +163,7 @@ public class ChoreController {
         }
         choreRepository.save(chore);
 
-        return "redirect:/chores";
+        return "redirect:/chores/detail?choreId=" + choreId;
     }
 
 

--- a/src/main/java/org/launchcode/liftoffproject/controllers/ChoreController.java
+++ b/src/main/java/org/launchcode/liftoffproject/controllers/ChoreController.java
@@ -152,6 +152,19 @@ public class ChoreController {
         return "redirect:/chores";
     }
 
+    //Endpoint for reject a child's chore completion
+    @PostMapping("/reject")
+    public String markChoreIncomplete(@RequestParam Integer choreId, @RequestParam boolean completed) {
+        Chore chore = choreRepository.findById(choreId).orElse(null);
+
+        if (chore != null) {
+            chore.setCompleted(false);
+            chore.setApprovedByParent(false);
+        }
+        choreRepository.save(chore);
+
+        return "redirect:/chores";
+    }
 
 
 

--- a/src/main/resources/templates/chores/detail.html
+++ b/src/main/resources/templates/chores/detail.html
@@ -68,6 +68,11 @@
       <button type="submit" class="btn btn-primary">Mark as Complete</button>
   </form>
 
+    <form th:if="${chore.completed}" th:action="@{/chores/reject(choreId=${chore.id},completed=true)}" method="post">
+        <input type="hidden" name="choreId" th:value="${chore.id}" />
+        <button type="submit" class="btn btn-warning">Reject (Mark as Incomplete)</button>
+    </form>
+
   <!-- Approve Chore Form -->
   <form th:unless="${childUser}" th:action="@{/chores/approve}" method="post">
       <input type="hidden" name="choreId" th:value="${chore.id}" />

--- a/src/main/resources/templates/chores/detail.html
+++ b/src/main/resources/templates/chores/detail.html
@@ -65,6 +65,7 @@
   <!-- Mark as Complete Form -->
   <form th:unless="${chore.completed}" th:action="@{/chores/complete(choreId=${chore.id},completed=true)}" method="post">
       <input type="hidden" name="choreId" th:value="${chore.id}" />
+      <input type="hidden" name="source" th:value="'/chores/detail?choreId=' + ${chore.id}" />
       <button type="submit" class="btn btn-primary">Mark as Complete</button>
   </form>
 

--- a/src/main/resources/templates/chores/detail.html
+++ b/src/main/resources/templates/chores/detail.html
@@ -63,7 +63,7 @@
     <a th:unless="${childUser}" class="btn btn-outline-dark" th:href="'/chores/edit?choreId=' + ${chore.id}" role="button">Edit This Task</a>
 
   <!-- Mark as Complete Form -->
-  <form th:unless="${chore.completed}" th:action="@{/chores/complete(choreId=${chore.id},completed=true)}" method="get">
+  <form th:unless="${chore.completed}" th:action="@{/chores/complete(choreId=${chore.id},completed=true)}" method="post">
       <input type="hidden" name="choreId" th:value="${chore.id}" />
       <button type="submit" class="btn btn-primary">Mark as Complete</button>
   </form>

--- a/src/main/resources/templates/chores/detail.html
+++ b/src/main/resources/templates/chores/detail.html
@@ -68,10 +68,12 @@
       <button type="submit" class="btn btn-primary">Mark as Complete</button>
   </form>
 
+    <div th:unless="${childUser}">
     <form th:if="${chore.completed}" th:action="@{/chores/reject(choreId=${chore.id},completed=true)}" method="post">
         <input type="hidden" name="choreId" th:value="${chore.id}" />
         <button type="submit" class="btn btn-warning">Reject (Mark as Incomplete)</button>
     </form>
+    </div>
 
   <!-- Approve Chore Form -->
   <form th:unless="${childUser}" th:action="@{/chores/approve}" method="post">

--- a/src/main/resources/templates/chores/index.html
+++ b/src/main/resources/templates/chores/index.html
@@ -63,6 +63,7 @@
                 <td th:if="${chore.childAssigned}">
                     <form th:unless="${chore.completed}" th:action="@{/chores/complete(choreId=${chore.id},completed=true)}" method="post">
                         <input type="hidden" name="choreId" th:value="${chore.id}" />
+                        <input type="hidden" name="source" th:value="@{/chores}" />
                         <button type="submit" class="btn btn-primary">Mark as Complete</button>
                     </form>
                     <span th:if="${chore.completed}" class="text-success">Completed</span>

--- a/src/main/resources/templates/chores/index.html
+++ b/src/main/resources/templates/chores/index.html
@@ -61,9 +61,10 @@
                 <td th:text="${chore.rewardPoints}"></td>
                 <td th:text="${chore.supplies}"></td>
                 <td th:if="${chore.childAssigned}">
-                    <a th:href="@{/chores/complete(choreId=${chore.id},completed=true)}"
-                                       class="btn btn-primary"
-                                       th:if="${not chore.completed}">Mark as Complete</a>
+                    <form th:unless="${chore.completed}" th:action="@{/chores/complete(choreId=${chore.id},completed=true)}" method="post">
+                        <input type="hidden" name="choreId" th:value="${chore.id}" />
+                        <button type="submit" class="btn btn-primary">Mark as Complete</button>
+                    </form>
                     <span th:if="${chore.completed}" class="text-success">Completed</span>
                 </td>
                 <td th:unless="${chore.childAssigned}">

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -2,7 +2,7 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org/">
 <head th:replace="fragments :: head">
     <meta charset="UTF-8"/>
-    <title>Child Dashboard</title>
+    <title>Dashboard</title>
 
 </head>
 <body class="dashboard">
@@ -252,9 +252,10 @@
             <td th:text="${#temporals.format(chore.dueDate, 'yyyy-MM-dd')}"></td>
             <td th:text="${chore.rewardPoints}"></td>
             <td>
-                <a th:href="@{/chores/complete(choreId=${chore.id},completed=true)}"
-                   class="btn btn-primary"
-                   th:if="${not chore.completed}">Mark as Complete</a>
+                <form th:unless="${chore.completed}" th:action="@{/chores/complete(choreId=${chore.id},completed=true)}" method="post">
+                    <input type="hidden" name="choreId" th:value="${chore.id}" />
+                    <button type="submit" class="btn btn-primary">Mark as Complete</button>
+                </form>
                 <span th:if="${chore.completed}" class="text-success">Completed</span>
             </td>
         </tr>

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -254,6 +254,7 @@
             <td>
                 <form th:unless="${chore.completed}" th:action="@{/chores/complete(choreId=${chore.id},completed=true)}" method="post">
                     <input type="hidden" name="choreId" th:value="${chore.id}" />
+                    <input type="hidden" name="source" th:value="@{/dashboard}" />
                     <button type="submit" class="btn btn-primary">Mark as Complete</button>
                 </form>
                 <span th:if="${chore.completed}" class="text-success">Completed</span>


### PR DESCRIPTION
I've added a new method and corresponding button to the chore details page that allows a parent to "reject" a child's chore completion, which changes it back to `completed=false` and then the child will see it again as a task they are assigned.

I also reworked the `complete` buttons to be a post method instead of a get method. I had to fix that in a few places, so if you find another spot where it's broken, let me know!