### PR TITLE
138 as a parent i can create a crew member who does not have an account

### DIFF
--- a/src/main/java/org/launchcode/liftoffproject/controllers/CrewController.java
+++ b/src/main/java/org/launchcode/liftoffproject/controllers/CrewController.java
@@ -34,6 +34,9 @@ public class CrewController {
     @Autowired
     private ParentRepository parentRepository;
 
+    @Autowired
+    private AuthenticationController authenticationController;
+
     private static final String userSessionKey = "user";
 
     public ParentUser getParentFromSession(HttpSession session) {
@@ -57,6 +60,18 @@ public class CrewController {
         model.addAttribute("crew", childRepository.findAllByParent(getParentFromSession(session).getParent()));
         return "crew/index";
     };
+
+    @PostMapping("create")
+    public String processAddCrewMemberNoAccount(@ModelAttribute @Valid Child newChild, Errors errors, Model model, HttpSession session) {
+        if (errors.hasErrors()) {
+            model.addAttribute("title","New Crew Member");
+            return "redirect:/crew";
+        }
+        Parent parent = authenticationController.getParentFromSession(session);
+        newChild.setParent(parent);
+        childRepository.save(newChild);
+        return "redirect:/crew";
+    }
 
     @GetMapping("add")
     public String renderAddCrewMemberForm(Model model) {

--- a/src/main/resources/templates/chores/detail.html
+++ b/src/main/resources/templates/chores/detail.html
@@ -74,7 +74,7 @@
   <!-- Mark as Complete Form -->
     <div class="section-buffer">
         <h2 class="text-center">Task Status</h2>
-  <form th:unless="${chore.completed}" th:action="@{/chores/complete(choreId=${chore.id},completed=true)}" method="get">
+  <form th:unless="${chore.completed}" th:action="@{/chores/complete(choreId=${chore.id},completed=true)}" method="post">
       <input type="hidden" name="choreId" th:value="${chore.id}" />
       <input type="hidden" name="source" th:value="'/chores/detail?choreId=' + ${chore.id}" />
       <button type="submit" class="btn btn-primary">Mark as Complete</button>

--- a/src/main/resources/templates/chores/index.html
+++ b/src/main/resources/templates/chores/index.html
@@ -35,7 +35,7 @@
                 <td th:if="${chore.isCompleted and !chore.isApprovedByParent}"><span class="text-warning">Pending Approval</span></td>
                 <td th:if="${!chore.isCompleted and !chore.isApprovedByParent}">
                     <span th:if="${!chore.isCompleted and chore.dueDate < today}" class="text-danger">Overdue</span>
-                    <span th:if="${!chore.isCompleted and chore.dueDate > today}" class="primary">Incomplete</span>
+                    <span th:if="${!chore.isCompleted and chore.dueDate >= today}" class="primary">Incomplete</span>
                 </td>
             </tr>
         </table>

--- a/src/main/resources/templates/crew/index.html
+++ b/src/main/resources/templates/crew/index.html
@@ -30,7 +30,27 @@
         </tr>
     </table>
 
-  <a class="btn btn-outline-dark" href="/crew/add" role="button">Add a new Crew Member</a>
+
+
+    <h2 class="text-center">Add Crew Members</h2>
+
+    <p>Add a crew member below.</p>
+    <form method="post" action="/crew/create">
+        <div class="form-group">
+            <label for="firstName">First Name:</label>
+            <input type="text" id="firstName" name="firstName" class="form-control" required />
+        </div>
+        <div class="form-group">
+            <label for="lastName">Last Name:</label>
+            <input type="text" id="lastName" name="lastName" class="form-control" required />
+        </div>
+        <div class="form-group">
+            <input type="submit" value="Add Crew Member" class="btn btn-success">
+        </div>
+    </form>
+
+    <p>Want your crew member to have an account instead? Click the button below:</p>
+    <a class="btn btn-outline-dark" href="/crew/add" role="button">Add a new Crew Member with an Account</a>
   
 </main>
 

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -105,7 +105,7 @@
                     <td th:if="${chore.isCompleted and !chore.isApprovedByParent}"><span class="text-warning">Pending Approval</span></td>
                     <td th:if="${!chore.isCompleted and !chore.isApprovedByParent}">
                         <span th:if="${!chore.isCompleted and chore.dueDate < today}" class="text-danger">Overdue</span>
-                        <span th:if="${!chore.isCompleted and chore.dueDate > today}" class="primary">Incomplete</span>
+                        <span th:if="${!chore.isCompleted and chore.dueDate >= today}" class="primary">Incomplete</span>
                     </td>
                 </tr>
             </table>


### PR DESCRIPTION
I added a simple "Add Crew Member" form to the bottom of the `crew/index` page that only includes First and Last name. If a parent submits the form, they will create a Crew Member (Child object) with no associated ChildUser account. Useful for cases where parents don't want to have separate logins for children.

Future issues will: 
-create an edit page
-be able to add a ChildUser account *after* creating a Child